### PR TITLE
Don't set a Content-Type header for GET requests

### DIFF
--- a/src/JsonApi/Http.elm
+++ b/src/JsonApi/Http.elm
@@ -55,9 +55,7 @@ get url handler =
     Http.request
         { method = "GET"
         , headers =
-            [ Http.header "Content-Type" "application/vnd.api+json"
-            , Http.header "Accept" "application/vnd.api+json"
-            ]
+            [ Http.header "Accept" "application/vnd.api+json" ]
         , url = url
         , body = Http.emptyBody
         , expect = Http.expectStringResponse handler


### PR DESCRIPTION
I propose to not use set the Content-Type header for GET requests:

* Content-Type specifies the format of the data we send to the server. GET requests don't have a request body
* By having the ```Content-Type``` header this requires a OPTIONS preflight request, see https://m.alphasights.com/killing-cors-preflight-requests-on-a-react-spa-1f9b04aa5730 for someone debugging a similar problem. Conceptually GET requests should be "simple" requests: https://developer.mozilla.org/en-US/docs/Web/HTTP/Access_control_CORS